### PR TITLE
add jscs git submodule, add scripts to test - ref #2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "jscs"]
+	path = jscs
+	url = https://github.com/jscs-dev/node-jscs

--- a/.npmignore
+++ b/.npmignore
@@ -3,3 +3,4 @@
 *.log
 *.cache
 .*
+jscs

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "bootstrap": "git submodule update --init && cd jscs && npm install",
     "jscs": "cd jscs && mocha --colors",
     "test": "mocha",
-    "lint": "./node_modules/.bin/jscs .",
+    "lint": "./node_modules/.bin/jscs test index.js acorn-to-esprima.js",
     "travis": "npm test && npm run lint"
   },
   "author": "Henry Zhu <hi@henryzoo.com>",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "lodash.assign": "^3.2.0"
   },
   "scripts": {
+    "bootstrap": "git submodule update --init && cd jscs && npm install",
+    "jscs": "cd jscs && mocha --colors",
     "test": "mocha",
     "lint": "./node_modules/.bin/jscs .",
     "travis": "npm test && npm run lint"


### PR DESCRIPTION
Similar to https://github.com/babel/babel-eslint/pull/116.

Need to figure out how to run the rules tests with `babel-jscs` instead of the regular esprima parser.

Errors: https://gist.github.com/hzoo/b8ae7b0a0b552063bb51 (had to manually change the jscs code to change the parser which is not viable)
