### PR TITLE
remove monkeypatch of estraverse, move to jscs itself

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,98 +1,7 @@
 var acornToEsprima = require("./acorn-to-esprima");
-var assign         = require("lodash.assign");
-var Module         = require("module");
 var parse          = require("babel-core").parse;
-var path           = require("path");
-var t              = require("babel-core").types;
-
-var estraverse;
-var hasPatched = false;
-
-function createModule(filename) {
-  var mod = new Module(filename);
-  mod.filename = filename;
-  mod.paths = Module._nodeModulePaths(path.dirname(filename));
-  return mod;
-}
-
-function monkeypatch() {
-  if (hasPatched) return;
-  hasPatched = true;
-
-  var jscsLoc;
-  try {
-    jscsLoc = Module._resolveFilename("jscs", module.parent.parent);
-  } catch (err) {
-    throw new ReferenceError("couldn't resolve jscs");
-  }
-
-  // get modules relative to what jscs will load
-  var jscsMod = createModule(jscsLoc);
-  var stringCheckerLoc = Module._resolveFilename("./string-checker", jscsMod);
-  var stringCheckerMod = createModule(stringCheckerLoc);
-  var JsFileLoc = Module._resolveFilename("./js-file", stringCheckerMod);
-  var JsFileMod = createModule(JsFileLoc);
-  var treeIteratorLoc = Module._resolveFilename("./tree-iterator", JsFileMod);
-  var treeIteratorMod = createModule(treeIteratorLoc);
-
-  // monkeypatch estraverse
-  estraverse = treeIteratorMod.require("estraverse");
-  assign(estraverse.VisitorKeys, t.VISITOR_KEYS);
-}
-
-exports.attachComments = function (ast, comments, tokens) {
-  estraverse.attachComments(ast, comments, tokens);
-
-  if (comments.length) {
-    var firstComment = comments[0];
-    var lastComment = comments[comments.length - 1];
-    // fixup program start
-    if (!tokens.length) {
-      // if no tokens, the program starts at the end of the last comment
-      ast.range[0] = lastComment.range[1];
-      ast.loc.start.line = lastComment.loc.end.line;
-      ast.loc.start.column = lastComment.loc.end.column;
-    } else if (firstComment.start < tokens[0].range[0]) {
-      // if there are comments before the first token, the program starts at the first token
-      var token = tokens[0];
-      ast.range[0] = token.range[0];
-      ast.loc.start.line = token.loc.start.line;
-      ast.loc.start.column = token.loc.start.column;
-
-      // estraverse do not put leading comments on first node when the comment
-      // appear before the first token
-      if (ast.body.length) {
-        var node = ast.body[0];
-        node.leadingComments = [];
-        var firstTokenStart = token.range[0];
-        var len = comments.length;
-        for (var i = 0; i < len && comments[i].start < firstTokenStart; i++) {
-          node.leadingComments.push(comments[i]);
-        }
-      }
-    }
-    // fixup program end
-    if (tokens.length) {
-      var lastToken = tokens[tokens.length - 1];
-      if (lastComment.end > lastToken.range[1]) {
-        // If there is a comment after the last token, the program ends at the
-        // last token and not the comment
-        ast.range[1] = lastToken.range[1];
-        ast.loc.end.line = lastToken.loc.end.line;
-        ast.loc.end.column = lastToken.loc.end.column;
-      }
-    }
-  }
-};
 
 exports.parse = function (code, mode) {
-  try {
-    monkeypatch();
-  } catch (err) {
-    console.error(err.stack);
-    process.exit(1);
-  }
-
   var opts = {
     locations: true,
     ranges: true,
@@ -127,7 +36,6 @@ exports.parse = function (code, mode) {
 
   // add comments
   ast.comments = comments;
-  exports.attachComments(ast, comments, tokens);
 
   // transform esprima and acorn divergent nodes
   acornToEsprima.toAST(ast);

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/jscs-dev/babel-jscs.git"
   },
   "dependencies": {
-    "babel-core": "^5.5.1",
+    "babel-core": "^5.6.14",
     "lodash.assign": "^3.2.0"
   },
   "scripts": {

--- a/test/babel-jscs.js
+++ b/test/babel-jscs.js
@@ -249,32 +249,33 @@ describe("acorn-to-esprima", function () {
     parseAndAssertSame("export { foo as bar };");
   });
 
-  it("empty program with line comment", function () {
-    parseAndAssertSame("// single comment");
-  });
+  // comment out tests since had to remove attachComment method of estraverse - #10
+  // it("empty program with line comment", function () {
+  //   parseAndAssertSame("// single comment");
+  // });
 
-  it("empty program with block comment", function () {
-    parseAndAssertSame("  /* multiline\n * comment\n*/");
-  });
+  // it("empty program with block comment", function () {
+  //   parseAndAssertSame("  /* multiline\n * comment\n*/");
+  // });
 
-  it("line comments", function () {
-    parseAndAssertSame([
-      "  // single comment",
-      "var foo = 15; // comment next to statement",
-      "// second comment after statement"
-    ].join("\n"));
-  });
+  // it("line comments", function () {
+  //   parseAndAssertSame([
+  //     "  // single comment",
+  //     "var foo = 15; // comment next to statement",
+  //     "// second comment after statement"
+  //   ].join("\n"));
+  // });
 
-  it("block comments", function () {
-    parseAndAssertSame([
-      "  /* single comment */ ",
-      "var foo = 15; /* comment next to statement */",
-      "/*",
-      " * multiline",
-      " * comment",
-      " */"
-    ].join("\n"));
-  });
+  // it("block comments", function () {
+  //   parseAndAssertSame([
+  //     "  /* single comment */ ",
+  //     "var foo = 15; /* comment next to statement */",
+  //     "/*",
+  //     " * multiline",
+  //     " * comment",
+  //     " */"
+  //   ].join("\n"));
+  // });
 
   it("null", function () {
     parseAndAssertSame("null");


### PR DESCRIPTION
Will need to remove the comment tests (because attachComment method is removed) and then use the merged jscs commit from https://github.com/jscs-dev/node-jscs/pull/1515 to pass the other test.

Pinning jscs to PR to make it pass.
