### PR TITLE
Being more prescriptive on the babel-core version

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/jscs-dev/babel-jscs.git"
   },
   "dependencies": {
-    "babel-core": "^5.6.14",
+    "babel-core": "~5.6.14",
     "lodash.assign": "^3.2.0"
   },
   "scripts": {


### PR DESCRIPTION
Should resolve #18 

As a longer term solution, we need to figure out what babel changed and how to update babel-jscs to support it. 
